### PR TITLE
Some test fixes.

### DIFF
--- a/myriad/myriad_object.py
+++ b/myriad/myriad_object.py
@@ -157,13 +157,13 @@ class MyriadObject(_MyriadObjectBase,
         # Render main file templates
         setattr(cls, "cuh_file_template",
                 MakoFileTemplate(
-                    os.path.join(template_dir.name, obj_name + ".cuh"),
+                    os.path.join(template_dir, obj_name + ".cuh"),
                     CUH_FILE_TEMPLATE,
                     local_namespace))
         LOG.debug("cuh_file_template done for %s", obj_name)
         setattr(cls, "cu_file_template",
                 MakoFileTemplate(
-                    os.path.join(template_dir.name, obj_name + ".cu"),
+                    os.path.join(template_dir, obj_name + ".cu"),
                     CU_FILE_TEMPLATE,
                     local_namespace))
         LOG.debug("cu_file_template done for %s", obj_name)
@@ -179,7 +179,7 @@ class MyriadObject(_MyriadObjectBase,
         local_namespace["pyc_scalar_types"] = pyc_scalars
         setattr(cls, "pyc_file_template",
                 MakoFileTemplate(
-                    os.path.join(template_dir.name, "py" + obj_name.lower() + ".c"),
+                    os.path.join(template_dir, "py" + obj_name.lower() + ".c"),
                     PYC_COMP_FILE_TEMPLATE,
                     local_namespace))
         LOG.debug("pyc_file_template done for %s", obj_name)
@@ -205,13 +205,13 @@ class MyriadObject(_MyriadObjectBase,
         if cls is MyriadObject:
             LOG.debug("Rendering PYC File for MyriadObject")
             c_template = MakoFileTemplate(
-                os.path.join(template_dir.name, "pymyriadobject.c"),
+                os.path.join(template_dir, "pymyriadobject.c"),
                 MYRIADOBJECT_PYC_FILE_TEMPLATE,
                 cls.__dict__)
             c_template.render_to_file(overwrite=False)
             LOG.debug("Rendering PYH File for MyriadObject")
             h_template = MakoFileTemplate(
-                os.path.join(template_dir.name, "pymyriadobject.h"),
+                os.path.join(template_dir, "pymyriadobject.h"),
                 MYRIADOBJECT_PYH_FILE_TEMPLATE,
                 cls.__dict__)
             h_template.render_to_file(overwrite=False)

--- a/myriad/myriad_simul.py
+++ b/myriad/myriad_simul.py
@@ -287,7 +287,7 @@ class MyriadSimul(_MyriadSimulParent, metaclass=_MyriadSimulMeta):
         template_dir_name = template_dir.name + os.sep
         # Render templates for dependencies into template_dir
         for dependency in getattr(self, "dependencies"):
-            dependency.render_templates(template_dir)
+            dependency.render_templates(template_dir.name)
         # Render templates into template_dir
         self._makefile_tmpl = MakoFileTemplate(
             template_dir_name + "Makefile",

--- a/myriad/templates/Makefile.mako
+++ b/myriad/templates/Makefile.mako
@@ -12,8 +12,11 @@ CUDA_LIB_PATH ?= $(CUDA_PATH)/lib/x86_64-linux-gnu/
 #######################
 
 NVCC ?= $(CUDA_BIN_PATH)/nvcc
-CC   := gcc-4.9
-CXX  := g++-4.9
+ifneq "$(shell expr `gcc -dumpversion | cut -f 1-2 -d.` \>= 4.9)" "1"
+    $(error gcc version 4.9 or greater is required)
+endif
+CC   := gcc
+CXX  := g++
 
 ####################
 ## Compiler Flags ##

--- a/tests/myriad_testing.py
+++ b/tests/myriad_testing.py
@@ -84,9 +84,11 @@ class MyriadTestCase(unittest.TestCase):
     TestCase class used to facilitate keeping logs of failed/error'd tests
     """
 
-    def assertFilesExist(self, base_cls):
+    def assertFilesExist(self, base_cls, base_dir=None):
         """ Raises AssertionError if template files do not exist """
         for filename in base_cls.get_file_list():
+            if base_dir:
+                filename = os.path.join(base_dir, filename)
             if not os.path.isfile(filename):
                 raise AssertionError("Template file not found: " + filename)
 

--- a/tests/test_ast_function_assembler.py
+++ b/tests/test_ast_function_assembler.py
@@ -29,7 +29,7 @@ class ASTFunctionTester(MyriadTestCase):
             return 0
         mfun = ast_func.pyfun_to_cfun(test_fun)
         self.assertIsNotNone(mfun)
-        expected_decl = "int64_t test_fun(int64_t a, int64_t b)"
+        expected_decl = "int_fast32_t test_fun(int_fast32_t a, int_fast32_t b)"
         self.assertTrimStrEquals(mfun.stringify_decl(), expected_decl)
 
     def test_simple_func_def(self):

--- a/tests/test_classparse.py
+++ b/tests/test_classparse.py
@@ -39,7 +39,7 @@ class TestClassParsing(MyriadTestCase):
     def test_parse_class_method_decl(self):
         """ Testing if parsing class method declarations works """
         m_fun = ast_function_assembler.pyfun_to_cfun(TestClass.test_method)
-        expected_decl = "int64_t test_method(void *self, int64_t a, int64_t b)"
+        expected_decl = "int_fast32_t test_method(void *self, int_fast32_t a, int_fast32_t b)"
         self.assertTrimStrEquals(m_fun.stringify_decl(), expected_decl)
 
     def test_parse_class_method_def(self):

--- a/tests/test_myriad_metaclass.py
+++ b/tests/test_myriad_metaclass.py
@@ -34,7 +34,7 @@ class TestMyriadMethod(MyriadTestCase):
                                                              classname)
         # Compare result strings
         expected_result = """
-        void super_dtor(const int64_t _class, const void *self)
+        void super_dtor(const int_fast32_t _class, const void *self)
         {
         dtor_vtable[_class](self);
         return;

--- a/tests/test_myriad_metaclass.py
+++ b/tests/test_myriad_metaclass.py
@@ -60,9 +60,9 @@ class TestMyriadMethod(MyriadTestCase):
         result_fxn = myriad_metaclass.create_delegator(instance_fxn, classname)
         # Compare result strings
         expected_result = """
-        int64_t add_mech(void *_self, void *mechanism)
+        int_fast32_t add_mech(void *_self, void *mechanism)
         {
-        return add_mech_vtable[((struct MyriadObject*) obj)->class_id](self, mechanism);
+        return add_mech_vtable[((struct MyriadObject*) self)->class_id](self, mechanism);
         }
         """
         self.assertTrimStrEquals(str(result_fxn), expected_result)

--- a/tests/test_myriad_object.py
+++ b/tests/test_myriad_object.py
@@ -12,6 +12,7 @@ from myriad_testing import set_external_loggers, MyriadTestCase
 
 from context import myriad
 from myriad import myriad_types as mtypes
+from tempfile import TemporaryDirectory
 from myriad import myriad_metaclass as mclass
 from myriad import myriad_object as mobject
 
@@ -39,12 +40,12 @@ class TestMyriadMetaclass(MyriadTestCase):
 
     def test_create_variable_only_class(self):
         """ Testing if creating a variable-only metaclass works """
-        class VarOnlyObj(mobject.MyriadObject):
+        class VarOnlyObjCreate(mobject.MyriadObject):
             capacitance = mtypes.MDouble
             vm = mtypes.MyriadTimeseriesVector
-        result_str = VarOnlyObj.__dict__["obj_struct"].stringify_decl()
+        result_str = VarOnlyObjCreate.__dict__["obj_struct"].stringify_decl()
         expected_result = """
-        struct VarOnlyObj
+        struct VarOnlyObjCreate
         {
             const struct MyriadObject _;
             double capacitance;
@@ -74,40 +75,40 @@ class TestMyriadMetaclass(MyriadTestCase):
 
     def test_myriad_blank_init(self):
         """ Testing creating empty Myriad objects """
-        class InstanceObject(mobject.MyriadObject):
+        class InstanceObjectBlank(mobject.MyriadObject):
             pass
-        inst = InstanceObject()
+        inst = InstanceObjectBlank()
         self.assertIsNotNone(inst)
 
     def test_myriad_init(self):
         """ Testing creating a non-empty Myriad object """
-        class InstanceObject(mobject.MyriadObject):
+        class InstanceObjectDummy(mobject.MyriadObject):
             dummy = mtypes.MDouble
-        inst = InstanceObject(dummy=3.0)
+        inst = InstanceObjectDummy(dummy=3.0)
         self.assertIsNotNone(inst)
         self.assertTrue(hasattr(inst, "dummy"))
         self.assertEqual(getattr(inst, "dummy"), 3.0)
 
     def test_myriad_invalid_init(self):
         """ Testing creating Myriad object with invalid constructor calls """
-        class InstanceObject(mobject.MyriadObject):
+        class InstanceObjectInvalid(mobject.MyriadObject):
             dummy = mtypes.MDouble
         inst = None
         # No arguments - should fail
         try:
-            inst = InstanceObject()
+            inst = InstanceObjectInvalid()
         except ValueError:
             pass
         self.assertIsNone(inst)
         # Incorrect argument - should fail
         try:
-            inst = InstanceObject(bar="LOL")
+            inst = InstanceObjectInvalid(bar="LOL")
         except ValueError:
             pass
         self.assertIsNone(inst)
         # Incorrect argument type - should fail
         try:
-            inst = InstanceObject(value=1.0)
+            inst = InstanceObjectInvalid(value=1.0)
         except ValueError:
             pass
         self.assertIsNone(inst)
@@ -123,25 +124,28 @@ class TestMyriadRendering(MyriadTestCase):
         """ Testing if template rendering produces files """
         class RenderObj(mobject.MyriadObject):
             pass
-        RenderObj.render_templates()
-        self.assertFilesExist(RenderObj)
+        template_dir = TemporaryDirectory(prefix='RenderObj')
+        RenderObj.render_templates(template_dir=template_dir.name)
+        self.assertFilesExist(RenderObj, base_dir=template_dir.name)
         # self.cleanupFiles(RenderObj)
 
     def test_render_variable_only_class(self):
         """ Testing if rendering a variable-only class works """
-        class VarOnlyObj(mobject.MyriadObject):
+        class VarOnlyObjRender(mobject.MyriadObject):
             capacitance = mtypes.MDouble
-        VarOnlyObj.render_templates()
-        self.assertFilesExist(VarOnlyObj)
-        # self.cleanupFiles(VarOnlyObj)
+        template_dir = TemporaryDirectory(prefix='VarOnlyObjRender')
+        VarOnlyObjRender.render_templates(template_dir=template_dir.name)
+        self.assertFilesExist(VarOnlyObjRender, base_dir=template_dir.name)
+        # self.cleanupFiles(VarOnlyObjRender)
 
     def test_render_timeseries_class(self):
         """ Testing if rendering a timeseries-containing class works"""
         class TimeseriesObj(mobject.MyriadObject):
             capacitance = mtypes.MDouble
             vm = mtypes.MyriadTimeseriesVector
-        TimeseriesObj.render_templates()
-        self.assertFilesExist(TimeseriesObj)
+        template_dir = TemporaryDirectory(prefix='TimeseriesObj')
+        TimeseriesObj.render_templates(template_dir=template_dir.name)
+        self.assertFilesExist(TimeseriesObj, base_dir=template_dir.name)
         # self.cleanupFiles(TimeseriesObj)
 
 


### PR DESCRIPTION
The last commit `Object name is self.` does fix the test failure (that says it's supposed to be `self` and not `obj`), but it should probably be doubled checked it correct as I didn't walk through the whole code hierarchy to verify.
